### PR TITLE
Updated Firegento URL to HTTPS

### DIFF
--- a/provision/stubs/magento-composer.json
+++ b/provision/stubs/magento-composer.json
@@ -24,7 +24,7 @@
         },
         {
             "type": "composer",
-            "url": "http://packages.firegento.com"
+            "url": "https://packages.firegento.com"
         }
     ],
     "extra": {


### PR DESCRIPTION
Updating the Firegento URL to HTTPS as composer are now enforcing secure connections to remote repositories, as outlined in the below issue;

https://github.com/composer/composer/issues/4963
