### PR TITLE
Improved Magento 2 Performance

### DIFF
--- a/provision/magento2-bootstrap.sh
+++ b/provision/magento2-bootstrap.sh
@@ -148,6 +148,16 @@ magento setup:install --base-url=http://$domain/ \
 --use-rewrites=1 \
 --session-save=db
 
+echo "--- Reindexing Tables ---"
+magento indexer:reindex;
+
+echo "--- Flushing All Cache ---"
+magento cache:flush;
+
+echo "Adding REDIS cache settings"
+php /vagrant/provision/stubs/add_redis_env.php
+
 echo "Magento admin username = admin";
 echo "Magento admin password = password123";
 echo "Magento installed at http://$domain/. Remember and set your hosts file.";
+

--- a/provision/stubs/add_redis_env.php
+++ b/provision/stubs/add_redis_env.php
@@ -1,0 +1,51 @@
+<?php
+
+$file = "/vagrant/magento2/app/etc/env.php";
+$env = include $file;
+
+$env['cache'] =  
+	array (
+		'frontend' => 
+		array (
+			'default' => 
+			array (
+				'backend' => 'Cm_Cache_Backend_Redis',
+    		'backend_options' => 
+    		array (
+					'server' => '127.0.0.1',
+					'port' => '6379',
+					'persistent' => '',
+					'database' => '0',
+					'force_standalone' => '0',
+					'connect_retries' => '1',
+					'read_timeout' => '10',
+					'automatic_cleaning_factor' => '0',
+					'compress_data' => '1',
+					'compress_tags' => '1',
+					'compress_threshold' => '20480',
+					'compression_lib' => 'gzip',
+        )
+			),
+			'page_cache' => 
+			array (
+	      'backend' => 'Cm_Cache_Backend_Redis',
+	      'backend_options' => 
+		    array (
+					'server' => '127.0.0.1',
+					'port' => '6379',
+					'persistent' => '',
+					'database' => '1',
+					'force_standalone' => '0',
+					'connect_retries' => '1',
+					'read_timeout' => '10',
+					'automatic_cleaning_factor' => '0',
+					'compress_data' => '0',
+					'compress_tags' => '1',
+					'compress_threshold' => '20480',
+					'compression_lib' => 'gzip',
+				),
+			),
+		)
+	);
+
+file_put_contents($file, "<?php \n \n return ".var_export($env,true).";");


### PR DESCRIPTION
This PR improves Magento 2 performance out the box. (after cache has been built)
- [x] Add redis cache to `env` for Magento 2
- [x] Reindex during Magento 2 install
- [x] Flush cache on Magento 2 install
