### PR TITLE
Add PHP7 support for Magento 1.

### DIFF
--- a/provision/puphpet/magestead/magento/configure-nginx.sh
+++ b/provision/puphpet/magestead/magento/configure-nginx.sh
@@ -23,6 +23,9 @@ block="server {
         access_log off;
     }
 
+    access_log /var/log/nginx/$BASE_URL-access.log;
+    error_log /var/log/nginx/$BASE_URL-error.log error;
+
     ## These locations would be hidden by .htaccess normally
     location ^~ /app/                { deny all; }
     location ^~ /includes/           { deny all; }

--- a/provision/puphpet/magestead/magento/stubs/composer.tmp
+++ b/provision/puphpet/magestead/magento/stubs/composer.tmp
@@ -30,7 +30,8 @@
     "require": {
         "aydin-hassan/magento-core-composer-installer" : "~1.0",
         "magento/magento" : "1.9.2.2",
-        "magento-hackathon/magento-composer-installer": "3.0.*"
+        "magento-hackathon/magento-composer-installer": "3.0.*",
+        "inchoo/php7": "1.0.*"
     },
     "authors": [
         {

--- a/provision/puphpet/magestead/magento2/configure-nginx.sh
+++ b/provision/puphpet/magestead/magento2/configure-nginx.sh
@@ -16,6 +16,9 @@ block="server {
     autoindex off;
     charset off;
 
+    access_log /var/log/nginx/$BASE_URL-access.log;
+    error_log /var/log/nginx/$BASE_URL-error.log error;
+
     location / {
         try_files \$uri \$uri/ /index.php?\$args;
     }

--- a/src/Magestead/Command/NewCommand.php
+++ b/src/Magestead/Command/NewCommand.php
@@ -33,7 +33,6 @@ class NewCommand extends Command
         $this->addArgument('project', InputArgument::REQUIRED, 'Name your project directory');
     }
 
-
     /**
      * @param InputInterface $input
      * @param OutputInterface $output

--- a/src/Magestead/Helper/Options.php
+++ b/src/Magestead/Helper/Options.php
@@ -100,15 +100,13 @@ class Options
     protected function setApplicationSettings($helper, InputInterface $input, OutputInterface $output, $project)
     {
         $output->writeln('<comment>Lets configure your project\'s application</comment>');
-        if ($this->_phpVer !== '70') {
-            $appQuestion = new ChoiceQuestion(
-                "Which application do you want to install?",
-                ['Magento', 'Magento2'],
-                0
-            );
+        $appQuestion = new ChoiceQuestion(
+            "Which application do you want to install?",
+            ['Magento', 'Magento2'],
+            0
+        );
 
-            $this->_app = strtolower($helper->ask($input, $output, $appQuestion));
-        }
+        $this->_app = strtolower($helper->ask($input, $output, $appQuestion));
 
         $baseUrlQuestion = new Question("Enter your application's base_url ($project.dev): ", $project.'.dev');
         $this->_baseUrl  = strtolower($helper->ask($input, $output, $baseUrlQuestion));


### PR DESCRIPTION
PR resolves - 
- [x] Add Inchoo PHP7 extension to Magento composer file
- [x] Allow Magento 1 installs with PHP 7 selected
- [x] Fix missing NGINX server block logs

PR closes #43
