### PR TITLE
Change Magento from 1.9.2.2 to 1.9.2.4

### DIFF
--- a/provision/puphpet/magestead/magento/stubs/composer.tmp
+++ b/provision/puphpet/magestead/magento/stubs/composer.tmp
@@ -29,7 +29,7 @@
     },
     "require": {
         "aydin-hassan/magento-core-composer-installer" : "~1.0",
-        "magento/magento" : "1.9.2.2",
+        "firegento/magento" : "1.9.2.4",
         "magento-hackathon/magento-composer-installer": "3.0.*",
         "inchoo/php7": "1.0.*"
     },


### PR DESCRIPTION
This is an enhancement to use the latest version of 1.9 out right now.
